### PR TITLE
Extend 'on_cran' for #14

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,12 @@
 Package: ami
 Title: Checks for Various Computing Environments
 Version: 0.1.0.9000
-Authors@R: 
+Authors@R: c(
     person("Brian", "Connelly", , "bdc@bconnelly.net", role = c("aut", "cre", "cph"),
-           comment = c(ORCID = "0000-0002-9948-0379"))
+           comment = c(ORCID = "0000-0002-9948-0379")),
+    person("Mark", "Padgham", , "mark.padgham@email.com", role = c("ctb"),
+           comment = c(ORCID = "0000-0003-2172-5265"))
+  )
 Description: A collection of lightweight functions that can be
     used to determine the computing environment in which your code is
     running. This includes operating systems, continuous integration (CI)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.0
 URL: https://github.com/briandconnelly/ami,
     https://briandconnelly.github.io/ami/
 BugReports: https://github.com/briandconnelly/ami/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/briandconnelly/ami,
     https://briandconnelly.github.io/ami/
 BugReports: https://github.com/briandconnelly/ami/issues

--- a/R/cran.R
+++ b/R/cran.R
@@ -9,9 +9,9 @@
 #' documented in the issue on this packages' GitHub repository at
 #' \url{https://github.com/briandconnelly/ami/issues/14}.
 #'
-#' @param CRAN_pattern String to match against environment variables.
-#' @param n_CRAN_envvars If at least this number of environment variables match
-#' the `CRAN_pattern`, `on_cran()` returns `TRUE`.
+#' @param cran_pattern String to match against environment variables.
+#' @param n_cran_envvars If at least this number of environment variables match
+#' the `cran_pattern`, `on_cran()` returns `TRUE`.
 #' @return A logical value
 #' @export
 #'
@@ -19,15 +19,15 @@
 #' on_cran()
 #' Sys.setenv("_R_1" = 1)
 #' Sys.setenv("_R_2" = 2)
-#' on_cran(n_CRAN_envvars = 2L) # TRUE
-on_cran <- function(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L) {
-  assert_string(CRAN_pattern)
-  assert_integer(n_CRAN_envvars, 1L)
+#' on_cran(n_cran_envvars = 2L) # TRUE
+on_cran <- function(cran_pattern = "^_R_", n_cran_envvars = 5L) {
+  assert_string(cran_pattern)
+  assert_integer(n_cran_envvars, 1L)
 
   not_cran <- using_envvar("NOT_CRAN", value = "true")
   if (!not_cran) { # Not using the envvar
-    index <- grep(CRAN_pattern, names(Sys.getenv()))
-    not_cran <- length(index) < n_CRAN_envvars
+    index <- grep(cran_pattern, names(Sys.getenv()))
+    not_cran <- length(index) < n_cran_envvars
   }
   !not_cran
 }

--- a/R/cran.R
+++ b/R/cran.R
@@ -20,13 +20,13 @@
 #' Sys.setenv("_R_1" = 1)
 #' Sys.setenv("_R_2" = 2)
 #' on_cran(n_cran_envvars = 2L) # TRUE
-on_cran <- function(cran_pattern = "^_R_", n_cran_envvars = 5L) {
+on_cran <- function(cran_pattern = "_R_", n_cran_envvars = 5L) {
   assert_string(cran_pattern)
   assert_integer(n_cran_envvars, 1L)
 
   not_cran <- using_envvar("NOT_CRAN", value = "true")
   if (!not_cran) { # Not using the envvar
-    index <- grep(cran_pattern, names(Sys.getenv()))
+    index <- grep(cran_pattern, names(Sys.getenv()), fixed = TRUE)
     not_cran <- length(index) < n_cran_envvars
   }
   !not_cran

--- a/R/cran.R
+++ b/R/cran.R
@@ -6,6 +6,17 @@
 #'
 #' @examples
 #' on_cran()
-on_cran <- function() {
-  !using_envvar("NOT_CRAN", value = "true")
+#' Sys.setenv("_R_1" = 1)
+#' Sys.setenv("_R_2" = 2)
+#' on_cran(n_CRAN_envvars = 2L) # TRUE
+on_cran <- function(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L) {
+  assert_string(CRAN_pattern)
+  assert_integer(n_CRAN_envvars, 1L)
+
+  is_cran <- using_envvar("NOT_CRAN", value = "true")
+  if (!is_cran) { # Not using the envvar
+    index <- grep(CRAN_pattern, names(Sys.getenv()))
+    is_cran <- length(index) >= n_CRAN_envvars
+  }
+  is_cran
 }

--- a/R/cran.R
+++ b/R/cran.R
@@ -1,6 +1,17 @@
 #' @rdname cran
 #' @title Detect CRAN
 #'
+#' @description This function detects whether the current R environment is a
+#' CRAN machine or not. It returns `FALSE` if the `NOT_CRAN` environment
+#' variable used in "github/r-lib" packages like \pkg{devtools} and
+#' \pkg{testthat} is set to "true". If that variable is not set, the function
+#' examines other environment variables typically set on CRAN machines, as
+#' documented in the issue on this packages' GitHub repository at
+#' \url{https://github.com/briandconnelly/ami/issues/14}.
+#'
+#' @param CRAN_pattern String to match against environment variables.
+#' @param n_CRAN_envvars If at least this number of environment variables match
+#' the `CRAN_pattern`, `on_cran()` returns `TRUE`.
 #' @return A logical value
 #' @export
 #'

--- a/R/cran.R
+++ b/R/cran.R
@@ -13,10 +13,10 @@ on_cran <- function(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L) {
   assert_string(CRAN_pattern)
   assert_integer(n_CRAN_envvars, 1L)
 
-  is_cran <- using_envvar("NOT_CRAN", value = "true")
-  if (!is_cran) { # Not using the envvar
+  not_cran <- using_envvar("NOT_CRAN", value = "true")
+  if (!not_cran) { # Not using the envvar
     index <- grep(CRAN_pattern, names(Sys.getenv()))
-    is_cran <- length(index) >= n_CRAN_envvars
+    not_cran <- length(index) < n_CRAN_envvars
   }
-  is_cran
+  !not_cran
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ assert_string <- function(x, na_ok = FALSE, null_ok = FALSE) {
   invisible(x)
 }
 
-assert_integer <- function (x, len = 1L, null_ok = FALSE) {
+assert_integer <- function(x, len = 1L, null_ok = FALSE) {
   rlang::is_integerish(x, n = len) ||
     (length(x) == 1L && is.na(x) && isTRUE(null_ok)) ||
     (is.null(x) && isTRUE(null_ok))

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,3 +13,9 @@ assert_string <- function(x, na_ok = FALSE, null_ok = FALSE) {
   }
   invisible(x)
 }
+
+assert_integer <- function (x, len = 1L, null_ok = FALSE) {
+  rlang::is_integerish(x, n = len) ||
+    (length(x) == 1L && is.na(x) && isTRUE(null_ok)) ||
+    (is.null(x) && isTRUE(null_ok))
+}

--- a/man/ami-package.Rd
+++ b/man/ami-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Brian Connelly \email{bdc@bconnelly.net} (\href{https://orcid.org/0000-0002-9948-0379}{ORCID}) [copyright holder]
 
+Other contributors:
+\itemize{
+  \item Mark Padgham \email{mark.padgham@email.com} (\href{https://orcid.org/0000-0003-2172-5265}{ORCID}) [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -6,11 +6,23 @@
 \usage{
 on_cran(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L)
 }
+\arguments{
+\item{CRAN_pattern}{String to match against environment variables.}
+
+\item{n_CRAN_envvars}{If at least this number of environment variables match
+the \code{CRAN_pattern}, \code{on_cran()} returns \code{TRUE}.}
+}
 \value{
 A logical value
 }
 \description{
-Detect CRAN
+This function detects whether the current R environment is a
+CRAN machine or not. It returns \code{FALSE} if the \code{NOT_CRAN} environment
+variable used in "github/r-lib" packages like \pkg{devtools} and
+\pkg{testthat} is set to "true". If that variable is not set, the function
+examines other environment variables typically set on CRAN machines, as
+documented in the issue on this packages' GitHub repository at
+\url{https://github.com/briandconnelly/ami/issues/14}.
 }
 \examples{
 on_cran()

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -4,7 +4,7 @@
 \alias{on_cran}
 \title{Detect CRAN}
 \usage{
-on_cran(cran_pattern = "^_R_", n_cran_envvars = 5L)
+on_cran(cran_pattern = "_R_", n_cran_envvars = 5L)
 }
 \arguments{
 \item{cran_pattern}{String to match against environment variables.}

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -4,13 +4,13 @@
 \alias{on_cran}
 \title{Detect CRAN}
 \usage{
-on_cran(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L)
+on_cran(cran_pattern = "^_R_", n_cran_envvars = 5L)
 }
 \arguments{
-\item{CRAN_pattern}{String to match against environment variables.}
+\item{cran_pattern}{String to match against environment variables.}
 
-\item{n_CRAN_envvars}{If at least this number of environment variables match
-the \code{CRAN_pattern}, \code{on_cran()} returns \code{TRUE}.}
+\item{n_cran_envvars}{If at least this number of environment variables match
+the \code{cran_pattern}, \code{on_cran()} returns \code{TRUE}.}
 }
 \value{
 A logical value
@@ -28,5 +28,5 @@ documented in the issue on this packages' GitHub repository at
 on_cran()
 Sys.setenv("_R_1" = 1)
 Sys.setenv("_R_2" = 2)
-on_cran(n_CRAN_envvars = 2L) # TRUE
+on_cran(n_cran_envvars = 2L) # TRUE
 }

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -4,7 +4,7 @@
 \alias{on_cran}
 \title{Detect CRAN}
 \usage{
-on_cran()
+on_cran(CRAN_pattern = "^_R_", n_CRAN_envvars = 5L)
 }
 \value{
 A logical value
@@ -14,4 +14,7 @@ Detect CRAN
 }
 \examples{
 on_cran()
+Sys.setenv("_R_1" = 1)
+Sys.setenv("_R_2" = 2)
+on_cran(n_CRAN_envvars = 2L) # TRUE
 }

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -10,6 +10,8 @@ test_that("on_cran() works as expected", {
   )
 
   # Not on CRAN because default `n_CRAN_envvars` is 5:
+  # (And 'NOT_CRAN = NULL' removes that "NOT_CRAN" envvar, so the function jumps
+  # to testing envvars actually set on CRAN machines.)
   withr::with_envvar(
     new = list("_R_1" = 1, "_R_2" = 2, "NOT_CRAN" = NULL),
     expect_false(on_cran())

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -1,35 +1,27 @@
 test_that("on_cran() works as expected", {
+  # envvar set by default in testthat:
+  expect_true(using_envvar("NOT_CRAN", value = "true"))
+  expect_false(on_cran())
+
+  # But R CMD check is by default `--as-cran`, which sets enough "_R_..."
+  # envvars to pass `on_cran()` tests:
   withr::with_envvar(
-    new = c("NOT_CRAN" = "true"),
-    expect_false(on_cran())
+    new = c("NOT_CRAN" = "false"),
+    {
+      expect_false(using_envvar("NOT_CRAN", value = "true"))
+      expect_true(on_cran())
+    }
   )
 
+  # Use a custom `CRAN_pattern` to test all cases. the first fails because
+  # default `n_CRAN_envvars` is 5:
   withr::with_envvar(
-    new = c("NOT_CRAN" = NA),
-    expect_false(on_cran())
-  )
-
-  # Not on CRAN because default `n_CRAN_envvars` is 5:
-  # (And 'NOT_CRAN = NULL' removes that "NOT_CRAN" envvar, so the function jumps
-  # to testing envvars actually set on CRAN machines.)
-  withr::with_envvar(
-    new = list("_R_1" = 1, "_R_2" = 2, "NOT_CRAN" = NULL),
-    expect_false(on_cran())
-  )
+    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),
+    expect_false(on_cran(CRAN_pattern = "_A_"))
+    )
 
   withr::with_envvar(
-    new = list("_R_1" = 1, "_R_2" = 2, "NOT_CRAN" = NULL),
-    expect_true(on_cran(n_CRAN_envvars = 2L))
-  )
-
-  # Not on CRAN because default `CRAN_pattern` is "^_R_":
-  withr::with_envvar(
-    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = NULL),
-    expect_false(on_cran(n_CRAN_envvars = 2L))
-  )
-
-  withr::with_envvar(
-    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = NULL),
-    expect_true(on_cran(CRAN_pattern = "^_A_", n_CRAN_envvars = 2L))
+    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),
+    expect_true(on_cran(CRAN_pattern = "_A_", n_CRAN_envvars = 2L))
   )
 })

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -31,7 +31,7 @@ test_that("on_cran() works as expected", {
   withr::with_envvar(
     new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),
     expect_false(on_cran(cran_pattern = "_A_"))
-    )
+  )
 
   withr::with_envvar(
     new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -1,7 +1,11 @@
 test_that("on_cran() works as expected", {
-  # envvar set by default in testthat:
-  expect_true(using_envvar("NOT_CRAN", value = "true"))
-  expect_false(on_cran())
+  withr::with_envvar(
+    new = c("NOT_CRAN" = "true"),
+    {
+      expect_true(using_envvar("NOT_CRAN", value = "true"))
+      expect_false(on_cran())
+    }
+  )
 
   # But R CMD check is by default `--as-cran`, which sets enough "_R_..."
   # envvars to pass `on_cran()` tests:

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -19,7 +19,7 @@ test_that("on_cran() works as expected", {
       expect_true(using_testthat())
       n <- length(grep("_R_", names(Sys.getenv()), fixed = TRUE))
       if (n > 1L) {
-        expect_true(on_cran()) # R CMD check / CRAN
+        expect_true(on_cran(n_cran_envvars = n)) # R CMD check / CRAN
       } else {
         expect_false(on_cran()) # testthat
       }

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -19,6 +19,7 @@ test_that("on_cran() works as expected", {
       } else {
         expect_false(on_cran()) # testthat
       }
+    }
   )
 
   # Use a custom `CRAN_pattern` to test all cases. the first fails because

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -7,14 +7,18 @@ test_that("on_cran() works as expected", {
     }
   )
 
-  # But R CMD check is by default `--as-cran`, which sets enough "_R_..."
-  # envvars to pass `on_cran()` tests:
   withr::with_envvar(
     new = c("NOT_CRAN" = "false"),
     {
       expect_false(using_envvar("NOT_CRAN", value = "true"))
-      expect_true(on_cran())
-    }
+      # R CMD check, and therefore also `rcmdcheck::rcmdcheck`, sets enough
+      # "_R_..." envvars to pass `on_cran()` tests, but `testthat` sets none.
+      n <- length(grep("_R_", names(Sys.getenv()), fixed = TRUE))
+      if (n > 0L) {
+        expect_true(on_cran()) # R CMD check / CRAN
+      } else {
+        expect_false(on_cran()) # testthat
+      }
   )
 
   # Use a custom `CRAN_pattern` to test all cases. the first fails because

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -6,6 +6,28 @@ test_that("on_cran() works as expected", {
 
   withr::with_envvar(
     new = c("NOT_CRAN" = NA),
-    expect_true(on_cran())
+    expect_false(on_cran())
+  )
+
+  # Not on CRAN because default `n_CRAN_envvars` is 5:
+  withr::with_envvar(
+    new = list("_R_1" = 1, "_R_2" = 2, "NOT_CRAN" = NULL),
+    expect_false(on_cran())
+  )
+
+  withr::with_envvar(
+    new = list("_R_1" = 1, "_R_2" = 2, "NOT_CRAN" = NULL),
+    expect_true(on_cran(n_CRAN_envvars = 2L))
+  )
+
+  # Not on CRAN because default `CRAN_pattern` is "^_R_":
+  withr::with_envvar(
+    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = NULL),
+    expect_false(on_cran(n_CRAN_envvars = 2L))
+  )
+
+  withr::with_envvar(
+    new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = NULL),
+    expect_true(on_cran(CRAN_pattern = "^_A_", n_CRAN_envvars = 2L))
   )
 })

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -21,11 +21,11 @@ test_that("on_cran() works as expected", {
   # default `n_CRAN_envvars` is 5:
   withr::with_envvar(
     new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),
-    expect_false(on_cran(CRAN_pattern = "_A_"))
+    expect_false(on_cran(cran_pattern = "_A_"))
     )
 
   withr::with_envvar(
     new = list("_A_1" = 1, "_A_2" = 2, "NOT_CRAN" = "false"),
-    expect_true(on_cran(CRAN_pattern = "_A_", n_CRAN_envvars = 2L))
+    expect_true(on_cran(cran_pattern = "_A_", n_cran_envvars = 2L))
   )
 })

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -12,9 +12,13 @@ test_that("on_cran() works as expected", {
     {
       expect_false(using_envvar("NOT_CRAN", value = "true"))
       # R CMD check, and therefore also `rcmdcheck::rcmdcheck`, sets enough
-      # "_R_..." envvars to pass `on_cran()` tests, but `testthat` sets none.
+      # "_R_..." envvars to pass `on_cran()` tests, but `testthat` generally
+      # sets only one. Note that can't use `using_testthat()` here, because R
+      # CMD check loads testthat to runs tests, and so `using_testthat()` is
+      # always TRUE.
+      expect_true(using_testthat())
       n <- length(grep("_R_", names(Sys.getenv()), fixed = TRUE))
-      if (n > 0L) {
+      if (n > 1L) {
         expect_true(on_cran()) # R CMD check / CRAN
       } else {
         expect_false(on_cran()) # testthat


### PR DESCRIPTION
@briandconnelly This is a draft PR to extend your `on_cran` function to work properly in all environments beyond devtools/testthat. The defaults are taken from the `fda` package (no public source, so CRAN tarball only), and the only real difference between this and their version is that theirs allows the `CRAN_pattern` to be a vector of arbitrary length, although it defaults to the single value used here. The default `n_CRAN_envvars = 5L` is also theirs.