### PR TITLE
update cran example

### DIFF
--- a/R/cran.R
+++ b/R/cran.R
@@ -18,7 +18,7 @@
 #' @examples
 #' on_cran()
 #' withr::with_envvar (
-#'   list ("_R_1" = 1, "_R_2" = 2),
+#'   list ("NOT_CRAN" = "false", "_R_1" = 1, "_R_2" = 2),
 #'   on_cran(n_cran_envvars = 2L)
 #' )
 on_cran <- function(cran_pattern = "_R_", n_cran_envvars = 5L) {

--- a/R/cran.R
+++ b/R/cran.R
@@ -17,9 +17,10 @@
 #'
 #' @examples
 #' on_cran()
-#' Sys.setenv("_R_1" = 1)
-#' Sys.setenv("_R_2" = 2)
-#' on_cran(n_cran_envvars = 2L) # TRUE
+#' withr::with_envvar (
+#'   list ("_R_1" = 1, "_R_2" = 2),
+#'   on_cran(n_cran_envvars = 2L)
+#' )
 on_cran <- function(cran_pattern = "_R_", n_cran_envvars = 5L) {
   assert_string(cran_pattern)
   assert_integer(n_cran_envvars, 1L)

--- a/R/cran.R
+++ b/R/cran.R
@@ -17,8 +17,8 @@
 #'
 #' @examples
 #' on_cran()
-#' withr::with_envvar (
-#'   list ("_R_1" = 1, "_R_2" = 2),
+#' withr::with_envvar(
+#'   list("_R_1" = 1, "_R_2" = 2),
 #'   on_cran(n_cran_envvars = 2L)
 #' )
 on_cran <- function(cran_pattern = "_R_", n_cran_envvars = 5L) {

--- a/R/cran.R
+++ b/R/cran.R
@@ -17,8 +17,8 @@
 #'
 #' @examples
 #' on_cran()
-#' withr::with_envvar (
-#'   list ("NOT_CRAN" = "false", "_R_1" = 1, "_R_2" = 2),
+#' withr::with_envvar(
+#'   list("NOT_CRAN" = "false", "_R_1" = 1, "_R_2" = 2),
 #'   on_cran(n_cran_envvars = 2L)
 #' )
 on_cran <- function(cran_pattern = "_R_", n_cran_envvars = 5L) {

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -26,7 +26,8 @@ documented in the issue on this packages' GitHub repository at
 }
 \examples{
 on_cran()
-Sys.setenv("_R_1" = 1)
-Sys.setenv("_R_2" = 2)
-on_cran(n_cran_envvars = 2L) # TRUE
+withr::with_envvar (
+  list ("_R_1" = 1, "_R_2" = 2),
+  on_cran(n_cran_envvars = 2L)
+)
 }

--- a/man/cran.Rd
+++ b/man/cran.Rd
@@ -27,7 +27,7 @@ documented in the issue on this packages' GitHub repository at
 \examples{
 on_cran()
 withr::with_envvar (
-  list ("_R_1" = 1, "_R_2" = 2),
+  list ("NOT_CRAN" = "false", "_R_1" = 1, "_R_2" = 2),
   on_cran(n_cran_envvars = 2L)
 )
 }


### PR DESCRIPTION
@briandconnelly Just noticed that [the example for `on_cran()`](https://briandconnelly.github.io/ami/reference/cran.html) doesn't work on the last line. This PR fixes, as can be seen from the rendered example via my own clone [here](https://mpadge.github.io/ami2/reference/cran.html). Problem was that `pkgdown` also sets `NOT_CRAN`!