### PR TITLE
Update Bioconductor environmental variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 URL: https://github.com/briandconnelly/ami,
     https://briandconnelly.github.io/ami/
 BugReports: https://github.com/briandconnelly/ami/issues

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -2,10 +2,11 @@
 #' @title Detect Bioconductor
 #'
 #' @return A logical value
+#' @references Check the Bioconductor Build System: https://github.com/Bioconductor/BBS/
 #' @export
 #'
 #' @examples
 #' on_bioconductor()
 on_bioconductor <- function() {
-  using_envvar("BBS_HOME")
+  using_envvar("IS_BIOC_BUILD_MACHINE", "true")
 }

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -2,7 +2,9 @@
 #' @title Detect Bioconductor
 #'
 #' @return A logical value
+# nolint start
 #' @references Check the Bioconductor Build System: https://github.com/Bioconductor/BBS/
+# nolint end
 #' @export
 #'
 #' @examples

--- a/man/bioconductor.Rd
+++ b/man/bioconductor.Rd
@@ -15,3 +15,6 @@ Detect Bioconductor
 \examples{
 on_bioconductor()
 }
+\references{
+Check the Bioconductor Build System: https://github.com/Bioconductor/BBS/
+}

--- a/tests/testthat/test-bioconductor.R
+++ b/tests/testthat/test-bioconductor.R
@@ -1,11 +1,11 @@
 test_that("on_bioconductor() works as expected", {
   withr::with_envvar(
-    new = c("BBS_HOME" = "true"),
+    new = c("IS_BIOC_BUILD_MACHINE" = "true"),
     expect_true(on_bioconductor())
   )
 
   withr::with_envvar(
-    new = c("BBS_HOME" = NA),
+    new = c("IS_BIOC_BUILD_MACHINE" = NA),
     expect_false(on_bioconductor())
   )
 })


### PR DESCRIPTION
I came here after #14 to update on_bioconductor.
I couldn't find the BBS_home variable used in the Bioconductor documentation & configuration. 
The change updates the variable to the one currently documented/used:

This variable is documented as "Package code can use this to detect that it's running on a Bioconductor build machine" in the enviromental file of the latest Bioconductor versions: https://github.com/Bioconductor/BBS/blob/134de15c69fa8263abe3923328bb432627455765/3.20/Renviron.bioc#L60-L61

It is also set in the [Single package builder](https://github.com/Bioconductor/packagebuilder) (used for submissions to Bioconductor): https://github.com/Bioconductor/packagebuilder/blob/bf98061acd027852ed0b092fd861b6d68644e401/check.Renviron#L43

Note: I haven't redocumented the package as I am directly editing from Github.